### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides access to Federal Election Commission (FEC) campaign finance data through the OpenFEC API.
 
+<a href="https://glama.ai/mcp/servers/2ujrcuobzz">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/2ujrcuobzz/badge" alt="OpenFEC Server MCP server" />
+</a>
+
 ## Features
 
 - Search for candidates by name, state, or office


### PR DESCRIPTION
This PR adds a badge for the [MCP OpenFEC Server](https://glama.ai/mcp/servers/2ujrcuobzz) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/2ujrcuobzz">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/2ujrcuobzz/badge" alt="OpenFEC Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.